### PR TITLE
Add GSD to SCL. Often used for validation.

### DIFF
--- a/docker/creo_layercatalog.json
+++ b/docker/creo_layercatalog.json
@@ -632,7 +632,8 @@
 
         {
           "name": "SCL",
-          "aliases": ["IMG_DATA_Band_SCL_20m_Tile1_Data"]
+          "aliases": ["IMG_DATA_Band_SCL_20m_Tile1_Data"],
+          "gsd": 20
         },
 
         {


### PR DESCRIPTION
Found by running on hundreds of recent process graphs.

GSD does not get enriched for the SCL band by opensearch, so added manually. 
Opensearch link for creo: https://sh.dataspace.copernicus.eu/api/v1/catalog/1.0.0/collections