### PR TITLE
Add the nodeSelector and toleration values to the deployment of the spark-history-server

### DIFF
--- a/kubernetes/charts/spark-history-server/templates/deployment.yaml
+++ b/kubernetes/charts/spark-history-server/templates/deployment.yaml
@@ -36,3 +36,11 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}

--- a/kubernetes/charts/spark-history-server/values.yaml
+++ b/kubernetes/charts/spark-history-server/values.yaml
@@ -19,3 +19,5 @@ ingress:
   className: ""
   annotations: {}
 resources: {}
+nodeSelector: {}
+tolerations: []


### PR DESCRIPTION
This merge request adds 2 new values with defaults to the deployment.yaml template of the spark-history-server helm chart allowing users to define them to prevent them being scheduled on nodes that could disappear.