### PR TITLE
fix: avoid building python311 containers without geotrellis-dependnecies

### DIFF
--- a/docker/AlmaLinux/Dockerfile.almalinux8.5-spark-py-openeo
+++ b/docker/AlmaLinux/Dockerfile.almalinux8.5-spark-py-openeo
@@ -121,4 +121,4 @@ ENV ACCUMULO_CLIENT_CONF_PATH=client.conf
 ENV OTB_HOME=/usr
 ENV OTB_APPLICATION_PATH=/usr/lib/otb/applications
 
-ADD --chmod=755 https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/geotrellis-dependencies/2.5.0_2.12-SNAPSHOT/geotrellis-dependencies-2.5.0_2.12-SNAPSHOT.jar /opt/geotrellis-dependencies-static.jar
+# geotrellis-dependencies come from openeo-base

--- a/docker/AlmaLinux/Dockerfile.openeo-base
+++ b/docker/AlmaLinux/Dockerfile.openeo-base
@@ -13,17 +13,20 @@ RUN mkdir -p /opt/venv && \
 FROM ${OPENEO_IMAGE}
 ARG GEOTRELLIS_EXTENSIONS_VERSION=2.5.0_2.12-SNAPSHOT
 ARG GEOTRELLIS_BACKEND_ASSEMBLY_VERSION=0.4.6-2-openeo_2.12
+ARG GEOTRELLIS_DEPENDENCIES_VERSION=2.5.0_2.12-SNAPSHOT
 
 LABEL maintainer="VITO Remote Sensing"
 
 USER root
 
 WORKDIR /opt
-    
+
 
 RUN curl -v --fail -JO https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/geotrellis-extensions/${GEOTRELLIS_EXTENSIONS_VERSION}/geotrellis-extensions-${GEOTRELLIS_EXTENSIONS_VERSION}.jar  && \
     curl --fail https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/openeo-logging/${GEOTRELLIS_EXTENSIONS_VERSION}/openeo-logging-${GEOTRELLIS_EXTENSIONS_VERSION}.jar -o openeo-logging-static.jar && \
     ln -s geotrellis-extensions*jar geotrellis-extensions-static.jar
+
+ADD --chmod=755 https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/geotrellis-dependencies/${GEOTRELLIS_DEPENDENCIES_VERSION}/geotrellis-dependencies-${GEOTRELLIS_DEPENDENCIES_VERSION}.jar /opt/geotrellis-dependencies-static.jar
 
 COPY --from=build_stage /opt/venv /opt/venv
 


### PR DESCRIPTION
De geotrellis dependencies were added to the spark-py-openeo images but the py311 images comes from the creo docker file. By moving the dependencies to the openeo-base docker container it takes care of both the spark-py-openeo and creo image.