### PR TITLE
feature: avoid webhook of spark-operator

### DIFF
--- a/kubernetes/charts/sparkapplication/templates/sparkapplication.yaml
+++ b/kubernetes/charts/sparkapplication/templates/sparkapplication.yaml
@@ -45,47 +45,7 @@ spec:
   {{- end }}
   {{- end }}
   timeToLiveSeconds: {{ .Values.timeToLiveSeconds }}
-  {{- if or .Values.volumes (not .Values.existingConfigMaps) }}
-  volumes:
-  {{- with .Values.volumes }}
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- if .Values.configMaps.backendConfig }}
-    - configMap:
-        name: {{ include "sparkapplication.fullname" . }}-backend-config
-      name: {{ include "sparkapplication.fullname" . }}-backend-config
-  {{- end }}
-  {{- if .Values.configMaps.batchJobLog4j2 }}
-    - configMap:
-        name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
-      name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
-  {{- end }}
-  {{- if .Values.configMaps.customBatchConfig }}
-    - configMap:
-        name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
-      name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
-  {{- end }}
-  {{- if .Values.configMaps.httpCredentials }}
-    - configMap:
-        name: {{ include "sparkapplication.fullname" . }}-http-credentials
-      name: {{ include "sparkapplication.fullname" . }}-http-credentials
-  {{- end }}
-  {{- if .Values.configMaps.layerCatalog }}
-    - configMap:
-        name: {{ include "sparkapplication.fullname" . }}-layercatalog
-      name: {{ include "sparkapplication.fullname" . }}-layercatalog
-  {{- end }}
-  {{- if .Values.configMaps.log4j2 }}
-    - configMap:
-        name: {{ include "sparkapplication.fullname" . }}-log4j2
-      name: {{ include "sparkapplication.fullname" . }}-log4j2
-  {{- end }}
-  {{- if .Values.configMaps.prometheusConfig }}
-    - configMap:
-        name: {{ include "sparkapplication.fullname" . }}-prometheus-config
-      name: {{ include "sparkapplication.fullname" . }}-prometheus-config
-  {{- end }}
-  {{- end }}
+
   {{- if or .Values.jarDependencies .Values.fileDependencies }}
   deps:
     {{- if .Values.jarDependencies }}
@@ -109,75 +69,211 @@ spec:
     maxExecutors: {{ .Values.dynamicAllocation.maxExecutors }}
   {{- end }}
   driver:
-    {{- if .Values.driver.priorityClassName | default .Values.priorityClassName }}
-    priorityClassName: {{ .Values.driver.priorityClassName | default .Values.priorityClassName }}
-    {{- end }}
-    {{- if .Values.driver.affinity }}
-    affinity:
-{{ toYaml .Values.driver.affinity | indent 6 }}
-    {{- end }}
-    annotations:
-      {{- if .Values.configMaps.backendConfig }}
-      checksum/backend-config: {{ include (print $.Template.BasePath "/configmap_backend_config.yaml") . | sha256sum }}
-      {{- end }}
-      {{- if .Values.configMaps.batchJobLog4j2 }}
-      checksum/batch-job-log4j2: {{ include (print $.Template.BasePath "/configmap_batch_job_log4j2.yaml") . | sha256sum }}
-      {{- end }}
-      {{- if .Values.configMaps.customBatchConfig }}
-      checksum/custom-batch-config: {{ include (print $.Template.BasePath "/configmap_custom_batch_config.yaml") . | sha256sum }}
-      {{- end }}
-      {{- if .Values.configMaps.httpCredentials }}
-      checksum/http-credentials: {{ include (print $.Template.BasePath "/configmap_http_credentials.yaml") . | sha256sum }}
-      {{- end }}
-      {{- if .Values.configMaps.layerCatalog }}
-      checksum/layercatalog: {{ include (print $.Template.BasePath "/configmap_layercatalog.yaml") . | sha256sum }}
-      {{- end }}
-      {{- if .Values.configMaps.log4j2 }}
-      checksum/log4j2: {{ include (print $.Template.BasePath "/configmap_log4j2.yaml") . | sha256sum }}
-      {{- end }}
-      {{- if .Values.configMaps.prometheusConfig }}
-      checksum/prometheus-config: {{ include (print $.Template.BasePath "/configmap_prometheus_config.yaml") . | sha256sum }}
-      {{- end }}
-    env:
-      - name: IMAGE_NAME
-        value: {{ .Values.image }}:{{ .Values.imageVersion }}
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-    {{- if .Values.driver.env }}
-      {{- range $key, $value :=  .Values.driver.env }}
-      - name: {{ $key }}
-        value: {{ $value | quote }}
-      {{- end }}
-    {{- end }}
-    {{- with .Values.driver.extraEnv }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- with .Values.global.extraEnv }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- if .Values.configMaps.backendConfig }}
-      - name: OPENEO_BACKEND_CONFIG
-        value: "/opt/backend_config/backendconfig.py"
-    {{- end }}
+    template:
+      metadata:
+        annotations:
+          {{- if .Values.configMaps.backendConfig }}
+          checksum/backend-config: {{ include (print $.Template.BasePath "/configmap_backend_config.yaml") . | sha256sum }}
+          {{- end }}
+          {{- if .Values.configMaps.batchJobLog4j2 }}
+          checksum/batch-job-log4j2: {{ include (print $.Template.BasePath "/configmap_batch_job_log4j2.yaml") . | sha256sum }}
+          {{- end }}
+          {{- if .Values.configMaps.customBatchConfig }}
+          checksum/custom-batch-config: {{ include (print $.Template.BasePath "/configmap_custom_batch_config.yaml") . | sha256sum }}
+          {{- end }}
+          {{- if .Values.configMaps.httpCredentials }}
+          checksum/http-credentials: {{ include (print $.Template.BasePath "/configmap_http_credentials.yaml") . | sha256sum }}
+          {{- end }}
+          {{- if .Values.configMaps.layerCatalog }}
+          checksum/layercatalog: {{ include (print $.Template.BasePath "/configmap_layercatalog.yaml") . | sha256sum }}
+          {{- end }}
+          {{- if .Values.configMaps.log4j2 }}
+          checksum/log4j2: {{ include (print $.Template.BasePath "/configmap_log4j2.yaml") . | sha256sum }}
+          {{- end }}
+          {{- if .Values.configMaps.prometheusConfig }}
+          checksum/prometheus-config: {{ include (print $.Template.BasePath "/configmap_prometheus_config.yaml") . | sha256sum }}
+          {{- end }}
+        labels:
+          app.kubernetes.io/name: {{ .Release.Name | trunc 63 }}-driver
+          release: {{ .Release.Name | trunc 63 | quote }}
+          revision: {{ .Release.Revision | quote }}
+          sparkVersion: {{ .Values.sparkVersion | quote }}
+          version: {{ .Chart.Version | quote }}
+          {{- if .Values.driver.labels }}
+            {{- range $name, $value := .Values.driver.labels }}
+          {{ $name }}: {{ $value }}
+            {{- end }}
+          {{- end}}
+
+      spec:
+        {{- with .Values.initContainers }}
+        initContainers:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
+        containers:
+          - name: spark-kubernetes-driver
+            env:
+            - name: IMAGE_NAME
+              value: {{ .Values.image }}:{{ .Values.imageVersion }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- if .Values.driver.env }}
+              {{- range $key, $value :=  .Values.driver.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+              {{- end }}
+            {{- end }}
+            {{- with .Values.driver.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.global.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.configMaps.backendConfig }}
+            - name: OPENEO_BACKEND_CONFIG
+              value: "/opt/backend_config/backendconfig.py"
+            {{- end }}
+
+            {{- with .Values.driver.lifecycle}}
+            lifecycle:
+              {{- toYaml .Values.driver.lifecycle | nindent 14 }}
+            {{- end }}
+
+            {{- if or (or .Values.volumeMounts .Values.driver.volumeMounts) (not .Values.existingConfigMaps) }}
+            volumeMounts:
+              {{- with .Values.volumeMounts }}
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
+              {{- with .Values.driver.volumeMounts }}
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
+              {{- if not .Values.existingConfigMaps }}
+                {{- if .Values.configMaps.backendConfig }}
+              - mountPath: /opt/backend_config/backendconfig.py
+                name: {{ include "sparkapplication.fullname" . }}-backend-config
+                subPath: backendconfig.py
+                {{- end }}
+                {{- if .Values.configMaps.batchJobLog4j2 }}
+              - mountPath: /opt/batch_job_log4j2.xml
+                name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
+                subPath: batch_job_log4j2.xml
+                {{- end }}
+                {{- if .Values.configMaps.httpCredentials }}
+              - mountPath: /opt/http_credentials/http_credentials.json
+                name: {{ include "sparkapplication.fullname" . }}-http-credentials
+                subPath: http_credentials.json
+                {{- end }}
+                {{- if .Values.configMaps.customBatchConfig }}
+              - mountPath: /opt/venv/lib64/python{{ .Values.pythonVersion }}.{{ .Values.pythonMinorVersion }}/site-packages/openeogeotrellis/deploy/sparkapplication.yaml.j2
+                name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
+                subPath: sparkapplication.yaml.j2
+                {{- end }}
+                {{- if .Values.configMaps.layerCatalog }}
+              - mountPath: /opt/layercatalog.json
+                name: {{ include "sparkapplication.fullname" . }}-layercatalog
+                subPath: layercatalog.json
+                {{- end }}
+                {{- if .Values.configMaps.log4j2 }}
+              - mountPath: /opt/log4j2.xml
+                name: {{ include "sparkapplication.fullname" . }}-log4j2
+                subPath: log4j2.xml
+                {{- end }}
+                {{- if .Values.configMaps.prometheusConfig }}
+              - mountPath: /opt/prometheus_config.yaml
+                name: {{ include "sparkapplication.fullname" . }}-prometheus-config
+                subPath: prometheus_config.yaml
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- with .Values.driver.ports }}
+            ports:
+              {{ toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.driver.livenessProbe }}
+            livenessProbe:
+              {{ toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.driver.readinessProbe }}
+            readinessProbe:
+              {{ toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.driver.startupProbe }}
+            startupProbe:
+              {{ toYaml . | nindent 14 }}
+            {{- end }}
+
+        {{- if .Values.driver.priorityClassName | default .Values.priorityClassName }}
+        priorityClassName: {{ .Values.driver.priorityClassName | default .Values.priorityClassName }}
+        {{- end }}
+        {{- if .Values.driver.affinity }}
+        affinity:
+          {{- toYaml .Values.driver.affinity | nindent 10 }}
+        {{- end }}
+        {{- with .Values.driver.podSecurityContext }}
+        podSecurityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        securityContext:
+          privileged: {{ .Values.privileged }}
+
+        hostNetwork: {{ .Values.hostNetwork | default false}}
+        terminationGracePeriodSeconds: {{ .Values.driver.terminationGracePeriodSeconds }}
+        serviceAccount: {{ required "Please provide a rbac.serviceAccountDriver" .Values.rbac.serviceAccountDriver }}
+        {{- if or .Values.volumes (not .Values.existingConfigMaps) }}
+        volumes:
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.configMaps.backendConfig }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-backend-config
+            name: {{ include "sparkapplication.fullname" . }}-backend-config
+        {{- end }}
+        {{- if .Values.configMaps.batchJobLog4j2 }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
+            name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
+        {{- end }}
+        {{- if .Values.configMaps.customBatchConfig }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
+            name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
+        {{- end }}
+        {{- if .Values.configMaps.httpCredentials }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-http-credentials
+            name: {{ include "sparkapplication.fullname" . }}-http-credentials
+        {{- end }}
+        {{- if .Values.configMaps.layerCatalog }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-layercatalog
+            name: {{ include "sparkapplication.fullname" . }}-layercatalog
+        {{- end }}
+        {{- if .Values.configMaps.log4j2 }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-log4j2
+            name: {{ include "sparkapplication.fullname" . }}-log4j2
+        {{- end }}
+        {{- if .Values.configMaps.prometheusConfig }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-prometheus-config
+            name: {{ include "sparkapplication.fullname" . }}-prometheus-config
+        {{- end }}
+        {{- end }}
+
+
+
     {{- if .Values.driver.javaOptions }}
     javaOptions: {{ .Values.driver.javaOptions }}
     {{- end }}
-    {{- if .Values.driver.podSecurityContext }}
-    podSecurityContext:
-{{ toYaml .Values.driver.podSecurityContext | indent 6 }}
-    {{- end }}
-    {{- if .Values.driver.ports }}
-    ports:
-{{ toYaml .Values.driver.ports | indent 6 }}
-    {{- end }}
-    securityContext:
-      privileged: {{ .Values.privileged }}
+
     {{- if .Values.driver.cores }}
     cores: {{ .Values.driver.cores }}
     {{- end }}
@@ -187,109 +283,151 @@ spec:
     coreLimit: {{ .Values.driver.coreLimit }}
     memory: {{ .Values.driver.memory }}
     memoryOverhead: {{ .Values.driver.memoryOverhead }}
-    hostNetwork: {{ .Values.hostNetwork | default false}}
-    labels:
-      app.kubernetes.io/name: {{ .Release.Name | trunc 63 }}-driver
-      release: {{ .Release.Name | trunc 63 | quote }}
-      revision: {{ .Release.Revision | quote }}
-      sparkVersion: {{ .Values.sparkVersion | quote }}
-      version: {{ .Chart.Version | quote }}
-    {{- if .Values.driver.labels }}
-    {{- range $name, $value := .Values.driver.labels }}
-      {{ $name }}: {{ $value }}
-    {{- end }}
-    {{- end}}
-    serviceAccount: {{ required "Please provide a rbac.serviceAccountDriver" .Values.rbac.serviceAccountDriver }}
-  {{- if or (or .Values.volumeMounts .Values.driver.volumeMounts) (not .Values.existingConfigMaps) }}
-    volumeMounts:
-      {{- with .Values.volumeMounts }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-      {{- with .Values.driver.volumeMounts }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-    {{- if not .Values.existingConfigMaps }}
-    {{- if .Values.configMaps.backendConfig }}
-      - mountPath: /opt/backend_config/backendconfig.py
-        name: {{ include "sparkapplication.fullname" . }}-backend-config
-        subPath: backendconfig.py
-    {{- end }}
-    {{- if .Values.configMaps.batchJobLog4j2 }}
-      - mountPath: /opt/batch_job_log4j2.xml
-        name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
-        subPath: batch_job_log4j2.xml
-    {{- end }}
-    {{- if .Values.configMaps.httpCredentials }}
-      - mountPath: /opt/http_credentials/http_credentials.json
-        name: {{ include "sparkapplication.fullname" . }}-http-credentials
-        subPath: http_credentials.json
-    {{- end }}
-    {{- if .Values.configMaps.customBatchConfig }}
-      - mountPath: /opt/venv/lib64/python{{ .Values.pythonVersion }}.{{ .Values.pythonMinorVersion }}/site-packages/openeogeotrellis/deploy/sparkapplication.yaml.j2
-        name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
-        subPath: sparkapplication.yaml.j2
-    {{- end }}
-    {{- if .Values.configMaps.layerCatalog }}
-      - mountPath: /opt/layercatalog.json
-        name: {{ include "sparkapplication.fullname" . }}-layercatalog
-        subPath: layercatalog.json
-    {{- end }}
-    {{- if .Values.configMaps.log4j2 }}
-      - mountPath: /opt/log4j2.xml
-        name: {{ include "sparkapplication.fullname" . }}-log4j2
-        subPath: log4j2.xml
-    {{- end }}
-    {{- if .Values.configMaps.prometheusConfig }}
-      - mountPath: /opt/prometheus_config.yaml
-        name: {{ include "sparkapplication.fullname" . }}-prometheus-config
-        subPath: prometheus_config.yaml
-    {{- end }}
-    {{- end }}
-  {{- end }}
-    {{- if .Values.initContainers }}
-    initContainers:
-{{ toYaml .Values.initContainers | nindent 6 }}
-    {{- end }}
-    {{- if .Values.driver.lifecycle}}
-    lifecycle:
-{{ toYaml .Values.driver.lifecycle | nindent 6 }}
-    {{- end }}
-    terminationGracePeriodSeconds: {{ .Values.driver.terminationGracePeriodSeconds }}
+
+
   executor:
-    {{- if .Values.executor.affinity }}
-    affinity:
-{{ toYaml .Values.executor.affinity | nindent 6 }}
-    {{- end }}
-    env:
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-    {{- if .Values.executor.env }}
-      {{- range $key, $value :=  .Values.executor.env }}
-      - name: {{ $key }}
-        value: {{ $value | quote }}
-      {{- end }}
-    {{- end }}
-    {{- with .Values.executor.extraEnv }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- with .Values.global.extraEnv }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+    template:
+      metadata:
+        labels:
+          release: {{ .Release.Name | trunc 63 | quote }}
+          revision: {{ .Release.Revision | quote }}
+          sparkVersion: {{ .Values.sparkVersion | quote }}
+          version: {{ .Chart.Version | quote }}
+          {{- if .Values.executor.labels }}
+            {{- range $name, $value := .Values.executor.labels }}
+          {{ $name }}: {{ $value }}
+            {{- end }}
+          {{- end}}
+
+      spec:
+        {{- with .Values.initContainers }}
+        initContainers:
+          {{ toYaml . | nindent 10 }}
+        {{- end }}
+        containers:
+          - name: spark-kubernetes-executor
+            env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              {{- if .Values.executor.env }}
+                {{- range $key, $value :=  .Values.executor.env }}
+              - name: {{ $key }}
+                value: {{ $value | quote }}
+                {{- end }}
+              {{- end }}
+              {{- with .Values.executor.extraEnv }}
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
+              {{- with .Values.global.extraEnv }}
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
+
+            {{- if .Values.executor.lifecycle}}
+            lifecycle:
+              {{ toYaml .Values.executor.lifecycle | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.volumeMounts .Values.executor.volumeMounts }}
+            volumeMounts:
+              {{- with .Values.volumeMounts }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+              {{- with .Values.executor.volumeMounts }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+              {{- if not .Values.existingConfigMaps }}
+                {{- if .Values.configMaps.backendConfig }}
+              - mountPath: /opt/backend_config/backendconfig.py
+                name: {{ include "sparkapplication.fullname" . }}-backend-config
+                subPath: backendconfig.py
+                {{- end }}
+                {{- if .Values.configMaps.batchJobLog4j2 }}
+              - mountPath: /opt/batch_job_log4j2.xml
+                name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
+                subPath: batch_job_log4j2.xml
+                {{- end }}
+                {{- if .Values.configMaps.httpCredentials }}
+              - mountPath: /opt/http_credentials/http_credentials.json
+                name: {{ include "sparkapplication.fullname" . }}-http-credentials
+                subPath: http_credentials.json
+                {{- end }}
+                {{- if .Values.configMaps.prometheusConfig }}
+              - mountPath: /opt/prometheus_config.yaml
+                name: {{ include "sparkapplication.fullname" . }}-prometheus-config
+                subPath: prometheus_config.yaml
+                {{- end }}
+                {{- if .Values.configMaps.log4j2 }}
+              - mountPath: /opt/log4j2.xml
+                name: {{ include "sparkapplication.fullname" . }}-log4j2
+                subPath: log4j2.xml
+                {{- end }}
+              {{- end }}
+            {{- end }}
+
+        {{- if .Values.executor.affinity }}
+        affinity:
+          {{- toYaml .Values.executor.affinity | nindent 10 }}
+        {{- end }}
+        {{- if .Values.executor.podSecurityContext }}
+        podSecurityContext:
+          {{- toYaml .Values.executor.podSecurityContext | nindent 10 }}
+        {{- end }}
+        securityContext:
+          privileged: {{ .Values.privileged }}
+        hostNetwork: {{ .Values.hostNetwork | default false}}
+        terminationGracePeriodSeconds: {{ .Values.executor.terminationGracePeriodSeconds }}
+        serviceAccount: {{ .Values.rbac.serviceAccountExecutor }}
+        {{- if or .Values.volumes (not .Values.existingConfigMaps) }}
+        volumes:
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.configMaps.backendConfig }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-backend-config
+            name: {{ include "sparkapplication.fullname" . }}-backend-config
+        {{- end }}
+        {{- if .Values.configMaps.batchJobLog4j2 }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
+            name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
+        {{- end }}
+        {{- if .Values.configMaps.customBatchConfig }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
+            name: {{ include "sparkapplication.fullname" . }}-custom-batch-config
+        {{- end }}
+        {{- if .Values.configMaps.httpCredentials }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-http-credentials
+            name: {{ include "sparkapplication.fullname" . }}-http-credentials
+        {{- end }}
+        {{- if .Values.configMaps.layerCatalog }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-layercatalog
+            name: {{ include "sparkapplication.fullname" . }}-layercatalog
+        {{- end }}
+        {{- if .Values.configMaps.log4j2 }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-log4j2
+            name: {{ include "sparkapplication.fullname" . }}-log4j2
+        {{- end }}
+        {{- if .Values.configMaps.prometheusConfig }}
+          - configMap:
+              name: {{ include "sparkapplication.fullname" . }}-prometheus-config
+            name: {{ include "sparkapplication.fullname" . }}-prometheus-config
+        {{- end }}
+        {{- end }}
+
     {{- if .Values.executor.javaOptions }}
     javaOptions: {{ .Values.executor.javaOptions }}
     {{- end }}
-    {{- if .Values.executor.podSecurityContext }}
-    podSecurityContext:
-{{ toYaml .Values.executor.podSecurityContext | indent 6 }}
-    {{- end }}
-    securityContext:
-      privileged: {{ .Values.privileged }}
+
     {{- if .Values.executor.cores }}
     cores: {{ .Values.executor.cores }}
     {{- end }}
@@ -300,63 +438,8 @@ spec:
     instances: {{ .Values.executor.instances }}
     memory: {{ .Values.executor.memory }}
     memoryOverhead: {{ .Values.executor.memoryOverhead }}
-    hostNetwork: {{ .Values.hostNetwork | default false}}
-    labels:
-      release: {{ .Release.Name | trunc 63 | quote }}
-      revision: {{ .Release.Revision | quote }}
-      sparkVersion: {{ .Values.sparkVersion | quote }}
-      version: {{ .Chart.Version | quote }}
-    {{- if .Values.executor.labels }}
-    {{- range $name, $value := .Values.executor.labels }}
-      {{ $name }}: {{ $value }}
-    {{- end }}
-    {{- end}}
-    serviceAccount: {{ .Values.rbac.serviceAccountExecutor }}
-  {{- if or .Values.volumeMounts .Values.executor.volumeMounts }}
-    volumeMounts:
-      {{- with .Values.volumeMounts }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-      {{- with .Values.executor.volumeMounts }}
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
-    {{- if not .Values.existingConfigMaps }}
-    {{- if .Values.configMaps.backendConfig }}
-      - mountPath: /opt/backend_config/backendconfig.py
-        name: {{ include "sparkapplication.fullname" . }}-backend-config
-        subPath: backendconfig.py
-    {{- end }}
-    {{- if .Values.configMaps.batchJobLog4j2 }}
-      - mountPath: /opt/batch_job_log4j2.xml
-        name: {{ include "sparkapplication.fullname" . }}-batch-job-log4j2
-        subPath: batch_job_log4j2.xml
-    {{- end }}
-    {{- if .Values.configMaps.httpCredentials }}
-      - mountPath: /opt/http_credentials/http_credentials.json
-        name: {{ include "sparkapplication.fullname" . }}-http-credentials
-        subPath: http_credentials.json
-    {{- end }}
-    {{- if .Values.configMaps.prometheusConfig }}
-      - mountPath: /opt/prometheus_config.yaml
-        name: {{ include "sparkapplication.fullname" . }}-prometheus-config
-        subPath: prometheus_config.yaml
-    {{- end }}
-    {{- if .Values.configMaps.log4j2 }}
-      - mountPath: /opt/log4j2.xml
-        name: {{ include "sparkapplication.fullname" . }}-log4j2
-        subPath: log4j2.xml
-    {{- end }}
-    {{- end }}
-  {{- end }}
-    {{- if .Values.initContainers }}
-    initContainers:
-{{ toYaml .Values.initContainers | indent 6 }}
-    {{- end }}
-    {{- if .Values.executor.lifecycle}}
-    lifecycle:
-{{ toYaml .Values.executor.lifecycle | indent 6 }}
-    {{- end }}
-    terminationGracePeriodSeconds: {{ .Values.driver.terminationGracePeriodSeconds }}
+
+
   {{- if .Values.sparkUIOptions }}
   sparkUIOptions:
 {{ toYaml .Values.sparkUIOptions | indent 4 }}


### PR DESCRIPTION
This would have 2 benefits:
1) Avoid dependency on being able to call webhook when pods are created as part of spark lifecycle 2) Allow more advanced pod configuration (e.g. configure probes for the driver)