### PR TITLE
Use cwl_common_to_stac mechanism for FORCE processes

### DIFF
--- a/openeo-geopyspark-k8s-custom-processes/src/openeo_geopyspark_k8s_custom_processes/custom_processes.py
+++ b/openeo-geopyspark-k8s-custom-processes/src/openeo_geopyspark_k8s_custom_processes/custom_processes.py
@@ -485,7 +485,6 @@ def force_level2(args: ProcessArgs, env: EvalEnv) -> DriverDataCube:
         args,
         env,
         cwl_source,
-        stac_root="catalog.json",
         direct_s3_mode=False,
     )
 
@@ -1122,7 +1121,6 @@ def force_tsa(args: ProcessArgs, env: EvalEnv) -> DriverDataCube:
         args,
         env,
         cwl_source,
-        stac_root="catalog.json",
         direct_s3_mode=False,
     )
 

--- a/openeo-geopyspark-k8s-custom-processes/src/openeo_geopyspark_k8s_custom_processes/custom_processes.py
+++ b/openeo-geopyspark-k8s-custom-processes/src/openeo_geopyspark_k8s_custom_processes/custom_processes.py
@@ -478,12 +478,15 @@ def _cwl_dummy_stac_parallel(args: ProcessArgs, env: EvalEnv) -> DriverDataCube:
              schema={"type": "object", "subtype": "datacube"})
 )
 def force_level2(args: ProcessArgs, env: EvalEnv) -> DriverDataCube:
-    return cwl_common(
+    cwl_source = CwLSource.from_url(
+        "https://github.com/bcdev/apex-force-openeo/releases/latest/download/force-level2.cwl"
+    )
+    return cwl_common_to_stac(
         args,
         env,
-        CwLSource.from_url(
-            "https://github.com/bcdev/apex-force-openeo/releases/latest/download/force-level2.cwl"
-        ),
+        cwl_source,
+        stac_root="catalog.json",
+        direct_s3_mode=False,
     )
 
 
@@ -1112,12 +1115,15 @@ def force_level2(args: ProcessArgs, env: EvalEnv) -> DriverDataCube:
     )
 )
 def force_tsa(args: ProcessArgs, env: EvalEnv) -> DriverDataCube:
-    return cwl_common(
+    cwl_source = CwLSource.from_url(
+        "https://github.com/bcdev/apex-force-openeo/releases/latest/download/force-tsa.cwl"
+    )
+    return cwl_common_to_stac(
         args,
         env,
-        CwLSource.from_url(
-            "https://github.com/bcdev/apex-force-openeo/releases/latest/download/force-tsa.cwl"
-        ),
+        cwl_source,
+        stac_root="catalog.json",
+        direct_s3_mode=False,
     )
 
 


### PR DESCRIPTION
The FORCE custom processes previously used the old `cwl_common` mechanism that would result in the backend trying to create an openEO data cube from it (and failing).

This PR updates the FORCE processes to use `cwl_common_to_stac` instead, so that they should succeed.